### PR TITLE
Add homeassistant-myskoda

### DIFF
--- a/integration
+++ b/integration
@@ -893,6 +893,7 @@
   "sillyfrog/Automate-Pulse-v2",
   "Skarbo/hass-scinan-thermostat",
   "skodaconnect/homeassistant-skodaconnect",
+  "skodaconnect/homeassistant-myskoda",
   "Slalamander/Home-Assistant-Eetlijst",
   "slashback100/presence_simulation",
   "slesinger/HomeAssistant-BMR",


### PR DESCRIPTION
Skoda is switching API's, for this reason we have rebuilt the integration.

`homeassistant-myskoda` will be developed moving forward.  We're adding it here, and after we have sunsetted `homeassistant-skodaconnect`, a PR will be made to remove it, allowing users to switch

<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [X] The actions are passing without any disabled checks in my repository.
- [X] I've added a link to the action run on my repository below in the links section.
- [X] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/skodaconnect/homeassistant-myskoda/releases/tag/v1.7.1
Link to successful HACS action (without the `ignore` key): https://github.com/skodaconnect/homeassistant-myskoda/actions/runs/11700759412/job/32585413910
Link to successful hassfest action (if integration): https://github.com/skodaconnect/homeassistant-myskoda/actions/runs/11700759412/job/32585413612

